### PR TITLE
Fix builds on iptables version 1.8.9 or newer

### DIFF
--- a/src/libxt_WGOBFS.c
+++ b/src/libxt_WGOBFS.c
@@ -139,7 +139,7 @@ static struct xtables_target wg_obfs_reg[] = {
           },
 };
 
-static void _init(void)
+static void __attribute__((constructor)) _init(void)
 {
         xtables_register_targets(wg_obfs_reg,
                                  sizeof(wg_obfs_reg) / sizeof(*wg_obfs_reg));


### PR DESCRIPTION
Ever since [iptables commit ef108943f69a6e20533d58823740d3f0534ea8ec](https://git.netfilter.org/iptables/commit/?id=ef108943f69a6e20533d58823740d3f0534ea8ec), the `_init` macro has become guarded by `XTABLES_INTERNAL`, thus breaking this extension.

Explicitly specify the constructor attribute on the initialization function, which works on all versions.