### PR TITLE
Driver checksum additional resetting

### DIFF
--- a/src/xt_WGOBFS_main.c
+++ b/src/xt_WGOBFS_main.c
@@ -235,11 +235,11 @@ static unsigned int xt_obfs(struct sk_buff *skb,
         iph->check = 0;
         ip_send_check(iph);
 
-        /* CHECKSUM_PARTIAL: The driver is required to checksum the packet.
-         * With CHECKSUM_PARTIAL, the udp packet has good checksum in VM, bad
-         * checksum after leave VM. Set to CHECKSUM_NONE fixes the problem.
+        /* since we change the packet pretend that
+         * driver did not checksum it
          */
-        if (skb->ip_summed == CHECKSUM_PARTIAL)
+        if (skb->ip_summed == CHECKSUM_PARTIAL ||
+            skb->ip_summed == CHECKSUM_COMPLETE)
                 skb->ip_summed = CHECKSUM_NONE;
 
         /* recalculate udp header checksum */
@@ -338,6 +338,13 @@ static unsigned int xt_unobfs(struct sk_buff *skb,
         iph->tot_len = htons(ntohs(iph->tot_len) - rnd_len);
         iph->check = 0;
         ip_send_check(iph);
+
+        /* since we change the packet pretend that
+         * driver did not checksum it
+         */
+        if (skb->ip_summed == CHECKSUM_PARTIAL ||
+            skb->ip_summed == CHECKSUM_COMPLETE)
+                skb->ip_summed = CHECKSUM_NONE;
 
         /* recalculate udp header checksum */
         udph->len = htons(ntohs(udph->len) - rnd_len);


### PR DESCRIPTION
Tried to use WGOBFS on tunnel going through an another, tun device vpn, but it didn't work, packets were dropped between the mangle INPUT chain and the application (on kernel [Arch Linux 6.1 LTS](https://archlinux.org/packages/core/x86_64/linux-lts/)).
After research, it turns out that in these packets `skb->ip_summed` is equals to `CHECKSUM_COMPLETE`.
Not sure why they were dropped, looks like kernel rechecks that `skb->csum` is still valid.
Setting `skb->ip_summed` to `CHECKSUM_NONE` helped (leave packet size unchanged also helps).

In [xt_TCPMSS.c](https://github.com/torvalds/linux/blob/v6.5/net/netfilter/xt_TCPMSS.c#L190) checksum changes is handled by using `inet_proto_csum_replace*`, `csum_replace*`. Function `inet_proto_csum_replace4` [is changing](https://github.com/torvalds/linux/blob/v6.5/net/core/utils.c#L431) `skb->csum` if `skb->ip_summed == CHECKSUM_COMPLETE`. On practice `skb->csum` is modified only [on len change](https://github.com/torvalds/linux/blob/v6.5/net/netfilter/xt_TCPMSS.c#L180C44-L180C48) (so that explains why it helps to leave packet size unchanged).
Maybe this is right way to dial with checksums, without recalculating whole checksum.