### PR TITLE
Fix compilation on 6.12 when including unaligned.h

### DIFF
--- a/src/chacha.h
+++ b/src/chacha.h
@@ -6,9 +6,15 @@
 #ifndef _XT_CHACHA8_H
 #define _XT_CHACHA8_H
 
-#include <asm/unaligned.h>
 #include <linux/kernel.h>
 #include <linux/types.h>
+#include <linux/version.h>
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
+#include <asm/unaligned.h>
+#else
+#include <linux/unaligned.h>
+#endif
 
 enum chacha_lengths {
 	CHACHA20_NONCE_SIZE = 16,


### PR DESCRIPTION
Linux 6.12 had changed location of unaligned.h header, it is placed under linux dir now. Add check to include right version

Reference PR: https://github.com/DIGImend/digimend-kernel-drivers/pull/707